### PR TITLE
Delete unnecessary ts-ignore

### DIFF
--- a/src/commands/showTriggerInfo.ts
+++ b/src/commands/showTriggerInfo.ts
@@ -70,7 +70,6 @@ export async function showTriggerInfo(
                 name: triggerDesc.name,
                 params: params,
                 annotations: annotations,
-                //@ts-ignore
                 rules: triggerDesc.rules,
             });
         }


### PR DESCRIPTION
Hi!
Since version 3.21.2 of openwhisk-client-js, the type definition of field "rules" in Trigger is added.
No longer need to put ts-ignore to handle Trigger.rules without a warning.