### PR TITLE
Use same publisher with netbeans vscode extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
 	"name": "openwhisk-vscode-extension",
-	"displayName": "VSCode Extension for Apache Openwhisk",
+	"displayName": "Apache Openwhisk Extension",
 	"description": "VSCode Extension for Apache OpenWhisk",
 	"version": "1.1.0",
-	"publisher": "Apache Openwhisk",
-    "author": "Apache Software Foundation",
+	"publisher": "asf",
+	"author": "Apache Openwhisk",
 	"engines": {
 		"vscode": "^1.41.0"
 	},


### PR DESCRIPTION
## Description
Need to use the same publisher with the Netbeans to publish extension under ASF vendor.
(Apache Netbeans is using `asf` publisher)


https://github.com/apache/netbeans/blob/master/java/java.lsp.server/vscode/package.json
