### PR TITLE
Provide action kind parameter when update action code

### DIFF
--- a/src/commands/editAction.ts
+++ b/src/commands/editAction.ts
@@ -75,6 +75,7 @@ vscode.workspace.onDidSaveTextDocument(async (doc: vscode.TextDocument) => {
             await action.client.actions.update({
                 name: action.getFullName(),
                 action: doc.getText(),
+                kind: action.kind,
             });
             vscode.window.showInformationMessage(`The action code is updated`);
         }

--- a/src/commands/editAction.ts
+++ b/src/commands/editAction.ts
@@ -19,6 +19,7 @@ import * as fs from 'fs';
 import * as vscode from 'vscode';
 import * as os from 'os';
 import * as path from 'path';
+import { Exec } from 'openwhisk';
 import { showConfirmMessage } from '../common';
 
 const actionEditMap: { [key: string]: WskAction } = {};
@@ -43,16 +44,17 @@ export async function editAction(action: WskAction): Promise<void> {
         vscode.window.showErrorMessage("Can't edit sequence action type");
         return;
     }
-    if (content.exec.binary) {
+
+    if ((content.exec as Exec).binary) {
         vscode.window.showErrorMessage("Can't edit binary action code");
         return;
     }
-    if ((content.exec.kind as string) === 'blackbox' && !content.exec.code) {
+    if ((content.exec.kind as string) === 'blackbox' && !(content.exec as Exec).code) {
         vscode.window.showErrorMessage("Can't edit blackbox action without action code");
         return;
     }
-    if (content.exec.code) {
-        fs.writeFileSync(localFilePath, content.exec.code);
+    if ((content.exec as Exec).code) {
+        fs.writeFileSync(localFilePath, (content.exec as Exec).code);
     }
 
     vscode.workspace.openTextDocument(localFilePath).then((textDocument: vscode.TextDocument) => {

--- a/src/wskContent.ts
+++ b/src/wskContent.ts
@@ -46,10 +46,10 @@ export class ActionCodeProvider implements vscode.TextDocumentContentProvider {
         if (content.exec.kind === 'sequence') {
             return 'Codeview does not support sequence actions.';
         }
-        if ((content.exec.kind as string) === 'blackbox' && !content.exec.code) {
+        if ((content.exec.kind as string) === 'blackbox' && !(content.exec as openwhisk.Exec).code) {
             return 'Codeview does not support native docker actions.';
         }
-        return Promise.resolve(content.exec.code);
+        return Promise.resolve((content.exec as openwhisk.Exec).code);
     }
 }
 


### PR DESCRIPTION

## Changes

- Provide action kind when action is updated.
- There is a bug where if action kind is not provided, it returns to the default kind value.